### PR TITLE
opinionated PR

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,9 @@ Will return:
 
 ## API
 
-### `parse(input, cb)`
+### `words = parse(input)`
 Parses either a hex input string, or `Buffer`, and returns an
-array of PGP words. If `cb` is ommitted `parse` returns
-immediately.
+array of PGP words.
 
 #### input
 A hex formatted string or a `Buffer`.
@@ -34,10 +33,6 @@ var words = parse('E582')
 var words = parse(new Buffer('E582', 'hex'))
 var words = parse(new Buffer([ 229, 130 ]))
 ```
-
-#### cb
-An optional callback of the form `function (err, output) {}`
-invoked when the decoding is complete.
 
 ## Tests
 

--- a/index.js
+++ b/index.js
@@ -10,8 +10,11 @@ function accessWordList(byteStr, index) {
  * @returns an array of code words.
  */
 module.exports = function parse(input) {
-	return input
-		.toString('hex')
+	var str = input.toString('hex')
+	if (str.length % 2) {
+		throw new Error('Expected input to be an even length.')
+	}
+	return str
 		.match(/[0-9a-z]{2}/gi)
 		.map(accessWordList)
 }

--- a/index.js
+++ b/index.js
@@ -1,35 +1,17 @@
-var word_list = require('pgp-word-list')
+var wordList = require('pgp-word-list')
+
+function accessWordList(byteStr, index) {
+	var byte = parseInt(byteStr, 16)
+	return wordList[byte][index % 2]
+}
 
 /** Parse a hex input string into PGP code words.
  * @param input A {string} or {Buffer} containing bytes to decode.
- * @param cb An optional callback {Function}
- * @returns If cb is undefined, returns the array of code words.
+ * @returns an array of code words.
  */
-module.exports = function parse(input, cb) {
-	var output = []
-
-	// avoid thrown exceptions in async code
-	try {
-		input = Buffer.isBuffer(input) ? input : new Buffer(input, 'hex')
-	} catch (e) {
-		if (!cb) {
-			throw e
-		}
-    
-		return process.nextTick(function() {
-			return cb(e)
-		})
-	}
-  
-	for (var index = 0; index < input.length; ++index) {
-		output.push(word_list[input[index]][index % 2])
-	}
-
-	if (!cb) {
-		return output
-	} else {
-		return process.nextTick(function() {
-			return cb(null, output)
-		})
-	}
+module.exports = function parse(input) {
+	return input
+		.toString('hex')
+		.match(/[0-9a-z]{2}/gi)
+		.map(accessWordList)
 }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "test": "tap ./test/*.js"
   },
   "devDependencies": {
+    "dupe": "^1.0.0",
     "tap": "~0.4.4"
   },
   "dependencies": {

--- a/test/parse_test.js
+++ b/test/parse_test.js
@@ -1,26 +1,7 @@
 var test = require('tap').test
 var parse = require('../index.js')
-
-var throws_error = function(input) {
-	try {
-		parse(input)
-	} catch (e) {
-		return true
-	}
-	return false
-}
-
-test('invalid string lengths throws errors', function(t) {
-	t.ok(throws_error('A'))
-	t.notOk(throws_error('A1'))
-	t.ok(throws_error('A1A'))
-	t.notOk(throws_error('A1A1'))
-	t.ok(throws_error('A1A1A'))
-	t.notOk(throws_error('A1A1A1'))
-	t.ok(throws_error('A1A1A1A'))
-	t.notOk(throws_error('A1A1A1A1'))
-	t.end()
-})
+var wordList = require('pgp-word-list')
+var noDuplicates = require('dupe')
 
 test('buffer is supported', function (t) {
 	t.ok(parse(new Buffer('A1', 'hex')))
@@ -30,26 +11,19 @@ test('buffer is supported', function (t) {
 	t.end()
 })
 
-test('async is supported', function (t) {
-	parse(new Buffer('A1A1', 'hex'), function (err, output) {
-		t.equals(2, output.length, 'correct number of words')
-		t.end()
-	})
-})
-
-test('async does not throw', function (t) {
-	parse('A1A', function (err, output) {
-		t.ok(err)
-		t.end()
-	})
-})
+function pairIsGood(wordPair) {
+	return wordPair.length === 2
+}
 
 test('dep pgp-word-list is complete', function (t) {
-	for (var i = 0; i < 256; ++i) {
-		var words = parse(new Buffer([i, i]))
-		t.equals(2, words.length)
-		t.notEquals(words[0], words[1])
-	}
+	var flattened = [].concat.apply([], wordList)
+
+	t.equal(wordList.length, 256)
+	t.equal(flattened.length, 512)
+
+	t.ok(wordList.every(pairIsGood), 'word pairs are the corrent length')
+	t.ok(flattened.every(noDuplicates), 'no duplicate words')
+
 	t.end()
 })
 
@@ -61,7 +35,12 @@ test('four characters is correct two words', function(t) {
 })
 
 test('four characters is correct two words', function(t) {
-	var correct_words = ['topmost','Istanbul','Pluto','vagabond','treadmill','Pacific','brackish','dictator','goldfish','Medusa','afflict','bravado','chatter','revolver','Dupont','midsummer','stopwatch','whimsical','cowbell','bottomless']
+	var correct_words = [
+		'topmost', 'Istanbul', 'Pluto', 'vagabond', 'treadmill',
+		'Pacific', 'brackish', 'dictator', 'goldfish', 'Medusa',
+		'afflict', 'bravado', 'chatter', 'revolver', 'Dupont',
+		'midsummer', 'stopwatch', 'whimsical', 'cowbell', 'bottomless'
+	]
 	var words = parse('E58294F2E9A227486E8B061B31CC528FD7FA3F19')
 	t.equals(20, words.length, 'correct number of words')
 	for (var i = 0; i < words.length; i++) {

--- a/test/parse_test.js
+++ b/test/parse_test.js
@@ -3,6 +3,18 @@ var parse = require('../index.js')
 var wordList = require('pgp-word-list')
 var noDuplicates = require('dupe')
 
+test('invalid string lengths throws errors', function(t) {
+	t.throws(      parse.bind(null, 'A'))
+	t.doesNotThrow(parse.bind(null, 'A1'))
+	t.throws(      parse.bind(null, 'A1A'))
+	t.doesNotThrow(parse.bind(null, 'A1A1'))
+	t.throws(      parse.bind(null, 'A1A1A'))
+	t.doesNotThrow(parse.bind(null, 'A1A1A1'))
+	t.throws(      parse.bind(null, 'A1A1A1A'))
+	t.doesNotThrow(parse.bind(null, 'A1A1A1A1'))
+	t.end()
+})
+
 test('buffer is supported', function (t) {
 	t.ok(parse(new Buffer('A1', 'hex')))
 	t.ok(parse(new Buffer('A1A1A1A1A1', 'hex')))


### PR DESCRIPTION
**Took out callback**
The callback made the process act asynchronous when it was synchronous. I didn't see any benefit to this.

**Removed error throwing**
If someone passes in something like `'1234567'`, it will be interpreted as `[ '12', '34', '56' ]` instead of throwing an error because of the trailing '7'.

Thoughts?